### PR TITLE
Use a more inclusive dependency selector for pronto

### DIFF
--- a/pronto-shellcheck.gemspec
+++ b/pronto-shellcheck.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.requirements << 'shellcheck (in PATH)'
 
-  s.add_dependency('pronto', '~> 0.7.0')
+  s.add_dependency('pronto', '>= 0.7.0')
   s.add_development_dependency('rake', '~> 11.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('pry-byebug')


### PR DESCRIPTION
This should resolve dependencies easier when pronto is installed with latest. This way someone can file an issue when it stops working instead of continuously updating the gemspec to catch up with pronto's pace.