### PR TITLE
Ignore submodules by requiring items to be files

### DIFF
--- a/lib/pronto/shellcheck_runner.rb
+++ b/lib/pronto/shellcheck_runner.rb
@@ -26,7 +26,12 @@ module Pronto
 
     class << self
       def shellcheckable?(path)
-        path_has_extension?(path) || file_has_shebang?(path)
+        regular_file?(path) &&
+          (path_has_extension?(path) || file_has_shebang?(path))
+      end
+
+      def regular_file?(path)
+        File.file?(path)
       end
 
       def path_has_extension?(path)

--- a/spec/pronto/shellcheck_runner_spec.rb
+++ b/spec/pronto/shellcheck_runner_spec.rb
@@ -125,6 +125,14 @@ module Pronto
         end
       end
 
+      context 'when the path is a directory' do
+        let(:filename) { 'directory' }
+
+        it 'returns true' do
+          expect(described_class.shellcheckable?(path)).to be false
+        end
+      end
+
       context 'when the path has no extension' do
         context "and the shebang includes 'sh'" do
           let(:filename) { 'shebang-sh' }


### PR DESCRIPTION
pronto/rugged will sometimes hand directories to tools to evaluate (an example would be when submodules are newly added and staged changes are requested); this skips them, since they're not valid input on their own to shellcheck.

Fixes #4 