### PR TITLE
Support for pronto 0.11.0

### DIFF
--- a/pronto-shellcheck.gemspec
+++ b/pronto-shellcheck.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.requirements << 'shellcheck (in PATH)'
 
-  s.add_dependency('pronto', '> 0.9.0', '< 0.11.0')
-  s.add_development_dependency('rake', '> 11.0', '< 13.0')
+  s.add_dependency('pronto', '> 0.9.0', '< 0.12.0')
+  s.add_development_dependency('rake', '> 11.0', '<= 13.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('pry-byebug')
 end


### PR DESCRIPTION
There are no breaking changes in [pronto 0.11.0](https://github.com/prontolabs/pronto/releases/tag/v0.11.0) we can safely update the version dependency restriction