### PR TITLE
runner: don't fail if shellcheck is not installed

### DIFF
--- a/lib/pronto/shellcheck_runner.rb
+++ b/lib/pronto/shellcheck_runner.rb
@@ -26,7 +26,7 @@ module Pronto
 
     class << self
       def shellcheckable?(path)
-        regular_file?(path) &&
+        shellcheck_installed? && regular_file?(path) &&
           (path_has_extension?(path) || file_has_shebang?(path))
       end
 
@@ -41,6 +41,18 @@ module Pronto
       def file_has_shebang?(path)
         shebang = File.readlines(path).first
         !(SHEBANG =~ shebang).nil?
+      end
+
+      def shellcheck_installed?
+        `shellcheck -V`
+
+        true
+      rescue Errno::ENOENT => _
+        if !@displayed_installation_warning
+          warn("WARNING: Shellcheck is not installed on your system. Ignoring the pronto runner")
+          @displayed_installation_warning = true
+        end
+        false
       end
     end
 


### PR DESCRIPTION
It is quite common to run `pronto` in a CI environment (continuous integration) to make sure that style / linting options on a repo are enforced at the PR level.
Thus it's the responsibility of the CI to have all dependencies installed to run **all configured pronto runners** on a dedicated repo.

However sometimes there are some tools not used by _all the contributors_ of a specific repository (e.g. some developers make changes only on frontend related code while some others only make changes on backend code for instance).

In this context, the goal of this PR is to remove the **hard** dependency on the `shellcheck` binary. With this change, a **warning** message will be given to the user but it won't raise an exception (and by consequence stop any other pronto runners).